### PR TITLE
fix: translator strategy

### DIFF
--- a/lib/helpers/util.dart
+++ b/lib/helpers/util.dart
@@ -1,4 +1,3 @@
-import 'package:sprintf/sprintf.dart';
 import 'package:uuid/uuid.dart';
 
 class Util {
@@ -29,10 +28,6 @@ class Util {
 
   static String? timeToDate(DateTime? time) {
     if (time == null) return null;
-    return sprintf('%04d-%02d-%02d', [
-      time.year,
-      time.month,
-      time.day,
-    ]);
+    return '${time.year}-${time.month.toString().padLeft(2, '0')}-${time.day.toString().padLeft(2, '0')}';
   }
 }

--- a/lib/providers/language_provider.dart
+++ b/lib/providers/language_provider.dart
@@ -12,9 +12,9 @@ class LanguageProvider extends ChangeNotifier {
   ];
 
   // List of all supported locales
-  static const delegates = [
+  static const delegates = <LocalizationsDelegate<dynamic>>[
     // A class which loads the translations from YAML files
-    Translator.delegate,
+    _LocalizationsDelegate(),
     // Built-in localization of basic text for Material widgets
     // (means those default Material widget such as alert dialog icon text)
     GlobalMaterialLocalizations.delegate,
@@ -22,7 +22,7 @@ class LanguageProvider extends ChangeNotifier {
     GlobalWidgetsLocalizations.delegate,
   ];
 
-  static const Locale defaultLocale = Locale('zh', 'TW');
+  static const Locale defaultLocale = Locale('en', 'US');
 
   Locale? _locale;
 
@@ -84,5 +84,26 @@ class LanguageProvider extends ChangeNotifier {
     final codes = value.split('_');
 
     return Locale(codes[0], codes.length == 1 ? null : codes[1]);
+  }
+}
+
+// LocalizationsDelegate is a factory for a set of localized resources
+// In this case, the localized strings will be gotten in an AppLocalizations object
+class _LocalizationsDelegate extends LocalizationsDelegate<Translator> {
+  const _LocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return true;
+  }
+
+  @override
+  bool shouldReload(_LocalizationsDelegate old) => false;
+
+  // already set in [LanguageProvider.localResolutionCallback]
+  @override
+  Future<Translator> load(Locale locale) async {
+    await Translator.instance.load(locale);
+    return Translator.instance;
   }
 }

--- a/lib/translator.dart
+++ b/lib/translator.dart
@@ -2,13 +2,9 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:sprintf/sprintf.dart';
 
 class Translator {
   static final Translator instance = Translator._constructor();
-
-  static const LocalizationsDelegate<Translator> delegate =
-      _LocalizationsDelegate();
 
   Map<String, String> _data = {};
 
@@ -23,37 +19,17 @@ class Translator {
     _data = data.cast<String, String>();
   }
 
-  String translate(String key, [List<dynamic>? args]) {
-    final value = _data[key] ?? key;
-    return args == null ? value : sprintf(value, args);
-  }
+  String translate(String key, Map<String, String> kvargs) {
+    var value = _data[key] ?? key;
 
-  static String t(String key, [List<dynamic>? args]) {
-    return instance.translate(key, args);
+    kvargs.forEach((key, value) {
+      value = value.replaceAll('{$key}', value);
+    });
+
+    return value;
   }
 }
 
-String tt(String key, [List<dynamic>? args]) {
-  return Translator.instance.translate(key, args);
-}
-
-// LocalizationsDelegate is a factory for a set of localized resources
-// In this case, the localized strings will be gotten in an AppLocalizations object
-class _LocalizationsDelegate extends LocalizationsDelegate<Translator> {
-  const _LocalizationsDelegate();
-
-  @override
-  bool isSupported(Locale locale) {
-    return true;
-  }
-
-  // already set in [LanguageProvider.localResolutionCallback]
-  @override
-  Future<Translator> load(Locale locale) async {
-    await Translator.instance.load(locale);
-    return Translator.instance;
-  }
-
-  @override
-  bool shouldReload(_LocalizationsDelegate old) => false;
+String tt(String key, [Map<String, String>? kvargs]) {
+  return Translator.instance.translate(key, kvargs ?? {});
 }

--- a/lib/ui/menu/catalog/catalog_screen.dart
+++ b/lib/ui/menu/catalog/catalog_screen.dart
@@ -36,7 +36,7 @@ class CatalogScreen extends StatelessWidget {
           Routes.menuProductModal,
           arguments: catalog,
         ),
-        tooltip: Translator.t('menu.catalog.add_product'),
+        tooltip: tt('menu.catalog.add_product'),
         child: Icon(KIcons.add),
       ),
       body: _body(catalog, context),

--- a/lib/ui/menu/menu_screen.dart
+++ b/lib/ui/menu/menu_screen.dart
@@ -38,7 +38,7 @@ class MenuScreen extends StatelessWidget {
       floatingActionButton: FloatingActionButton(
         onPressed: () => Navigator.of(context)
             .push(MaterialPageRoute(builder: (context) => CatalogModal())),
-        tooltip: Translator.t('menu.add_catalog'),
+        tooltip: tt('menu.add_catalog'),
         child: Icon(KIcons.add),
       ),
       // When click android go back, it will avoid closing APP

--- a/lib/ui/menu/product/product_screen.dart
+++ b/lib/ui/menu/product/product_screen.dart
@@ -37,7 +37,7 @@ class ProductScreen extends StatelessWidget {
           Routes.menuIngredient,
           arguments: product,
         ),
-        tooltip: Translator.t('menu.product.add_integredient'),
+        tooltip: tt('menu.product.add_integredient'),
         child: Icon(KIcons.add),
       ),
       body: _body(context, product),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -614,13 +614,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
-  sprintf:
-    dependency: "direct main"
-    description:
-      name: sprintf
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.0.0"
   sqflite:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,7 +49,6 @@ dependencies:
 
   # tools
   uuid: ^3.0.4
-  sprintf: ^6.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
#12 
同時完整移除 `sprintf`。
讓 Translator 功能單純，把 delegate 移到 `LanguageProvider`

修正錯誤：
若還未初始化就把 locale 給 MaterialApp 會讓 Translator 多 parse 預設的語言。