### PR TITLE
fix: remove snackbar action to avoid uncloseable.

### DIFF
--- a/lib/components/style/snackbar.dart
+++ b/lib/components/style/snackbar.dart
@@ -6,13 +6,11 @@ void showSnackBar(
   String message, {
   required Icon icon,
 }) {
+  // If want to add a "close" button, should consider taking root context, which is hard to handle.
   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
-    margin: const EdgeInsets.all(kSpacing2),
-    behavior: SnackBarBehavior.floating,
-    action: SnackBarAction(
-      label: '關閉',
-      onPressed: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(),
-    ),
+    // make floating button below
+    // behavior: SnackBarBehavior.floating,
+    // should not use icon, https://material.io/components/snackbars#anatomy
     content: Row(children: [
       icon,
       const SizedBox(width: kSpacing0),

--- a/test/ui/cashier/cashier_screen_test.dart
+++ b/test/ui/cashier/cashier_screen_test.dart
@@ -54,7 +54,6 @@ void main() {
 
     await tester.tap(find.text('confirm'));
     await tester.pumpAndSettle();
-    await tester.tap(find.text('關閉'));
   });
 
   testWidgets('should set default directly', (tester) async {


### PR DESCRIPTION
If want to add a "close" button, should consider taking root context, which is hard to handle.

resolves #93 