### PR TITLE
允許資料庫測試

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -728,6 +728,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.0"
+  sqflite_common_ffi:
+    dependency: "direct dev"
+    description:
+      name: sqflite_common_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0+2"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.5.1"
   stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,6 +78,7 @@ dev_dependencies:
   # mock object
   build_runner: ^2.1.7
   mockito: ^5.1.0
+  sqflite_common_ffi: ^2.1.0+2
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/mocks/mock_database.mocks.dart
+++ b/test/mocks/mock_database.mocks.dart
@@ -35,6 +35,14 @@ class MockDatabase extends _i1.Mock implements _i3.Database {
   set db(_i2.Database? _db) => super.noSuchMethod(Invocation.setter(#db, _db),
       returnValueForMissingStub: null);
   @override
+  int get oldVersion =>
+      (super.noSuchMethod(Invocation.getter(#oldVersion), returnValue: 0)
+          as int);
+  @override
+  set oldVersion(int? _oldVersion) =>
+      super.noSuchMethod(Invocation.setter(#oldVersion, _oldVersion),
+          returnValueForMissingStub: null);
+  @override
   _i4.Future<List<Object?>> batchUpdate(
           String? table, List<Map<String, Object?>>? data,
           {String? where, List<List<Object>>? whereArgs}) =>
@@ -79,8 +87,10 @@ class MockDatabase extends _i1.Mock implements _i3.Database {
               returnValue: Future<Map<String, Object?>?>.value())
           as _i4.Future<Map<String, Object?>?>);
   @override
-  _i4.Future<void> initialize() =>
-      (super.noSuchMethod(Invocation.method(#initialize, []),
+  _i4.Future<void> initialize(
+          {String? path, _i3.DbOpener? opener = _i2.openDatabase}) =>
+      (super.noSuchMethod(
+          Invocation.method(#initialize, [], {#path: path, #opener: opener}),
           returnValue: Future<void>.value(),
           returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
@@ -114,9 +124,10 @@ class MockDatabase extends _i1.Mock implements _i3.Database {
                   <Map<String, Object?>>[]))
           as _i4.Future<List<Map<String, Object?>>>);
   @override
-  _i4.Future<void> reset() => (super.noSuchMethod(Invocation.method(#reset, []),
-      returnValue: Future<void>.value(),
-      returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
+  _i4.Future<void> tolerateMigration([int? newVersion = 5]) =>
+      (super.noSuchMethod(Invocation.method(#tolerateMigration, [newVersion]),
+          returnValue: Future<void>.value(),
+          returnValueForMissingStub: Future<void>.value()) as _i4.Future<void>);
   @override
   _i4.Future<int> update(String? table, Object? key, Map<String, Object?>? data,
           {dynamic keyName = r'id'}) =>


### PR DESCRIPTION
發現當有錯誤的初始化 query（`CREATE`、`ALTER`）時，仍不能判斷該搜尋有錯

但是是個不錯的開始，順便修一下測試時加上的 `db.setVersion(4)`，並加上測試讓她不會再發生...

- #122 