### PR TITLE
fix: number before operator should fallback to zero

### DIFF
--- a/lib/ui/order/checkout/checkout_cashier_calculator.dart
+++ b/lib/ui/order/checkout/checkout_cashier_calculator.dart
@@ -234,14 +234,14 @@ class _CheckoutCashierCalculatorState extends State<CheckoutCashierCalculator> {
       final op = _operators.firstWhere((o) => val.contains(o));
       final parts = val.split(op).map((e) => num.tryParse(e)).map((e) => e ?? 0).toList();
 
-      switch (operator) {
+      switch (op) {
         case '+':
-          return parts[0]! + (parts[1] ?? 0);
+          return parts[0] + (parts[1] ?? 0);
         case '-':
-          return parts[0]! - (parts[1] ?? 0);
+          return parts[0] - (parts[1] ?? 0);
         case 'x':
         default:
-          return parts[0]! * (parts[1] ?? 1);
+          return parts[0] * (parts[1] ?? 1);
       }
     } on StateError {
       return fallback;

--- a/lib/ui/order/checkout/checkout_cashier_calculator.dart
+++ b/lib/ui/order/checkout/checkout_cashier_calculator.dart
@@ -231,8 +231,8 @@ class _CheckoutCashierCalculatorState extends State<CheckoutCashierCalculator> {
   num _calc(String val, [num other = 0]) {
     final fallback = num.tryParse(val) ?? other;
     try {
-      final operator = _operators.firstWhere((o) => val.contains(o));
-      final parts = val.split(operator).map((e) => num.tryParse(e)).toList();
+      final op = _operators.firstWhere((o) => val.contains(o));
+      final parts = val.split(op).map((e) => num.tryParse(e)).map((e) => e ?? 0).toList();
 
       switch (operator) {
         case '+':

--- a/lib/ui/order/checkout/checkout_cashier_calculator.dart
+++ b/lib/ui/order/checkout/checkout_cashier_calculator.dart
@@ -232,7 +232,7 @@ class _CheckoutCashierCalculatorState extends State<CheckoutCashierCalculator> {
     final fallback = num.tryParse(val) ?? other;
     try {
       final op = _operators.firstWhere((o) => val.contains(o));
-      final parts = val.split(op).map((e) => num.tryParse(e)).map((e) => e ?? 0).toList();
+      final parts = val.split(op).map((e) => num.tryParse(e)).map((e) => e ?? (op == 'x' ? 1 : 0)).toList();
 
       switch (op) {
         case '+':

--- a/lib/ui/order/checkout/checkout_cashier_calculator.dart
+++ b/lib/ui/order/checkout/checkout_cashier_calculator.dart
@@ -236,12 +236,12 @@ class _CheckoutCashierCalculatorState extends State<CheckoutCashierCalculator> {
 
       switch (op) {
         case '+':
-          return parts[0] + (parts[1] ?? 0);
+          return parts[0] + parts[1];
         case '-':
-          return parts[0] - (parts[1] ?? 0);
+          return parts[0] - parts[1];
         case 'x':
         default:
-          return parts[0] * (parts[1] ?? 1);
+          return parts[0] * parts[1];
       }
     } on StateError {
       return fallback;


### PR DESCRIPTION
## Issue

```text
          Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Null check operator used on a null value. Error thrown .
       at _CheckoutCashierCalculatorState._calc(checkout_cashier_calculator.dart:241)
       at _CheckoutCashierCalculatorState._onNotify(checkout_cashier_calculator.dart:252)
       at ChangeNotifier.notifyListeners(change_notifier.dart:439)
       at ValueNotifier.value=(change_notifier.dart:564)
       at _CheckoutCashierCalculatorState.text=(checkout_cashier_calculator.dart:165)
       at _CheckoutCashierCalculatorState._execPostfix(checkout_cashier_calculator.dart:228)
       at _CalculatorPostfixAction.build.<fn>(checkout_cashier_calculator.dart:304)
       at _InkResponseState.handleTap(ink_well.dart:1185)
       at GestureRecognizer.invokeCallback(recognizer.dart:357)
       at TapGestureRecognizer.handleTapUp(tap.dart:653)
       at BaseTapGestureRecognizer._checkUp(tap.dart:307)
       at BaseTapGestureRecognizer.handlePrimaryPointer(tap.dart:240)
       at PrimaryPointerGestureRecognizer.handleEvent(recognizer.dart:718)
       at PointerRouter._dispatch(pointer_router.dart:97)
       at PointerRouter._dispatchEventToRoutes.<fn>(pointer_router.dart:143)
       at _LinkedHashMapMixin.forEach(dart:_compact_hash)
       at PointerRouter._dispatchEventToRoutes(pointer_router.dart:141)
       at PointerRouter.route(pointer_router.dart:131)
       at GestureBinding.handleEvent(binding.dart:530)
       at GestureBinding.dispatchEvent(binding.dart:499)
       at RendererBinding.dispatchEvent(binding.dart:460)
       at GestureBinding._handlePointerEventImmediately(binding.dart:437)
       at GestureBinding.handlePointerEvent(binding.dart:394)
       at GestureBinding._flushPointerEventQueue(binding.dart:341)
       at GestureBinding._handlePointerDataPacket(binding.dart:308)
```